### PR TITLE
Changed how Alert handles HeadingTemplate

### DIFF
--- a/BlazorBootstrap.Components/Alert.razor
+++ b/BlazorBootstrap.Components/Alert.razor
@@ -15,9 +15,13 @@
             </button>
         }
 
-        @if (null != this.HeadingTemplate || !string.IsNullOrEmpty(this.Heading))
+        @if (null != this.HeadingTemplate)
         {
-            <Heading Level="HeadingLevel.H4" class="alert-heading">@(this.HeadingTemplate ?? (object)this.Heading)</Heading>
+            @this.HeadingTemplate
+        }
+        else if (!string.IsNullOrEmpty(this.Heading))
+        {
+            <Heading Level="HeadingLevel.H4" class="alert-heading">@this.Heading</Heading>
         }
 
         @ChildContent


### PR DESCRIPTION
Changed the way the HeadingTemplate works. Now it works just as a placeholder, and if used, the full header markup has to be provided.